### PR TITLE
Integrate ts-belt for URL params and extract TrackList logic into hook

### DIFF
--- a/src/components/TrackList/TrackList.tsx
+++ b/src/components/TrackList/TrackList.tsx
@@ -1,27 +1,16 @@
 import React, { useEffect, useState } from "react";
 import styles from "./TrackList.module.css";
-import { deleteTrack, fetchTracks } from "../../features/tracks/trackSlice";
-import { useAppDispatch } from "../../hooks/redux-hook";
 import Preloader from "../Preloader/Preloader";
 import TrackListControls from "./TrackListControls";
 import TrackListContent from "./TrackListContent";
 import TrackListPagination from "./TrackListPagination";
-import { Track, TracksQueryParams } from "../../features/tracks/types";
+import { Track } from "../../features/tracks/types";
 import { useTracks } from "../../hooks/useTracks";
 import { useSelector } from "react-redux";
 import { RootState } from "../../store";
-import { fetchGenres } from "../../features/genres/genresSlice";
-import { useTrackSelection } from "../../hooks/useTrackSelection";
-import { useDebounce } from "../../hooks/useDebounce";
 import TrackBulkActions from "../TrackBulkActions/TrackBulkActions";
+import { useTrackList } from "./useTrackList";
 
-/**
- * Props for the TrackList component
- * @param onEditTrack - callback to open edit modal for a track
- * @param searchQuery - external search string (optional)
- * @param forceGoToFirstPage - flag to reset to first page when search changes
- * @param setForceGoToFirstPage - setter for forceGoToFirstPage flag
- */
 interface Props {
   onEditTrack: (track: Track) => void;
   searchQuery: string;
@@ -29,133 +18,32 @@ interface Props {
   setForceGoToFirstPage: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const TrackList: React.FC<Props> = ({
-  onEditTrack,
-  searchQuery,
-  forceGoToFirstPage,
-  setForceGoToFirstPage,
-}) => {
-  const dispatch = useAppDispatch();
+const TrackList: React.FC<Props> = ({ onEditTrack, searchQuery }) => {
   // Select paginated track data and metadata from Redux state
-  const { items, status, page, limit, totalCount, totalPages, error } =
-    useTracks();
-  // Select available genres from Redux state
-  const { items: genres, status: genresStatus } = useSelector(
-    (s: RootState) => s.genres,
-  );
-  // Debounce external search input
-  const debouncedSearch = useDebounce(searchQuery, 500);
+  const { items, status, limit, totalPages, error } = useTracks();
 
-  // Hook for managing bulk selection and deletion
   const {
+    params,
+    onDelete,
+    onGenreChange,
+    onSortChange,
+    onDirectionToggle,
+    onPageChange,
     selectionMode,
     selectedTracks,
     toggleSelectionMode,
     toggleTrackSelection,
     handleSelectAll,
-    handleBulkDelete,
-  } = useTrackSelection();
-
-  // Wrapper to pass current params to bulk delete
-  const onBulkDelete = () => handleBulkDelete(selectedTracks, params);
-
-  // Fetch genres list on mount
-  useEffect(() => {
-    dispatch(fetchGenres())
-      .unwrap()
-      .catch((error) => {
-        console.error("Failed to fetch genres:", error);
-      });
-  }, [dispatch]);
-
-  // Unified local state for all query parameters
-  const [params, setParams] = useState<TracksQueryParams>({
-    page: 1,
-    limit: 10,
-    sort: "",
-    order: "asc",
-    // search and genre will be added later
-  });
-
-  // Fetch track list whenever params change
-  useEffect(() => {
-    dispatch(fetchTracks(params))
-      .unwrap()
-      .catch((error) => {
-        console.error("Failed to fetch tracks:", error);
-      });
-  }, [dispatch, params]);
-
-  // Reset to first page when external search flag triggers
-  useEffect(() => {
-    if (forceGoToFirstPage) {
-      setParams((p) => ({ ...p, page: 1 }));
-      window.scrollTo({ top: 0 });
-      setForceGoToFirstPage(false);
-    }
-  }, [forceGoToFirstPage, setForceGoToFirstPage]);
-
-  // Scroll to top on page change
-  useEffect(() => {
-    window.scrollTo({ top: 0 });
-  }, [params.page]);
-
-  // Update search param when debounced search changes
-  useEffect(() => {
-    setParams((p) => ({
-      ...p,
-      search: debouncedSearch || undefined,
-      page: 1,
-    }));
-  }, [debouncedSearch]);
-
-  /** Delete a single track by ID */
-  const handleDelete = (id: string) => {
-    dispatch(deleteTrack(id))
-      .unwrap()
-      .catch((error) => {
-        console.error("Failed to delete track:", error);
-      });
-  };
-
-  /** Handler for search input change */
-  const handleSearchChange = (value: string) =>
-    setParams((p) => ({ ...p, search: value || undefined, page: 1 }));
-
-  /** Handler for genre filter change */
-  const handleGenreChange = (genre: string) =>
-    setParams((p) => ({ ...p, genre: genre || undefined, page: 1 }));
-
-  /** Handler for sort field change */
-  const handleSortChange = (field: "" | "title" | "artist") =>
-    setParams((p) => ({
-      ...p,
-      sort: field,
-      order: p.sort === field && p.order === "asc" ? "desc" : "asc",
-      page: 1,
-    }));
-
-  /** Handler to toggle sort direction */
-  const handleDirectionToggle = () =>
-    setParams((p) => ({
-      ...p,
-      order: p.order === "asc" ? "desc" : "asc",
-      page: 1,
-    }));
-
-  /** Handler for pagination page change */
-  const handlePageChange = (newPage: number) =>
-    setParams((p) => ({ ...p, page: newPage }));
+    onBulkDelete,
+  } = useTrackList(searchQuery);
+  // Select available genres from Redux state
+  const { items: genres } = useSelector((s: RootState) => s.genres);
 
   // State for tracking which track is playing globally (index within items)
   const [currentPlayingIndex, setCurrentPlayingIndex] = useState<number | null>(
     null,
   );
 
-  /**
-   * When a track ends, play the next track in the current page or stop
-   * @param localIndex - position of the ended track in the current items array
-   */
   const handleTrackEnd = (localIndex: number) => {
     if (localIndex + 1 < items.length) {
       setCurrentPlayingIndex(localIndex + 1);
@@ -173,17 +61,16 @@ const TrackList: React.FC<Props> = ({
         <>
           {/* Controls for sorting, filtering, and searching */}
           <TrackListControls
-            sortBy={(params.sort ?? "") as "" | "title" | "artist"}
+            sortBy={params.sort ?? ""}
             sortDirection={params.order ?? "asc"}
-            onSortChange={handleSortChange}
-            onToggleDirection={handleDirectionToggle}
+            onSortChange={onSortChange}
+            onToggleDirection={onDirectionToggle}
             selectedGenre={params.genre ?? ""}
-            onGenreChange={handleGenreChange}
+            onGenreChange={onGenreChange}
             genres={genres}
-            setCurrentPage={handlePageChange}
+            setCurrentPage={onPageChange}
           />
 
-          {/* Bulk selection and deletion actions */}
           <TrackBulkActions
             selectionMode={selectionMode}
             selectedCount={selectedTracks.length}
@@ -193,25 +80,23 @@ const TrackList: React.FC<Props> = ({
             onBulkDelete={onBulkDelete}
           />
 
-          {/* Track list with player and actions */}
           <TrackListContent
             tracks={items}
-            startIndex={(params.page! - 1) * limit}
+            startIndex={((params.page ?? 1) - 1) * limit}
             currentPlayingIndex={currentPlayingIndex}
             setCurrentPlayingIndex={setCurrentPlayingIndex}
             onEditTrack={onEditTrack}
-            onDeleteTrack={handleDelete}
+            onDeleteTrack={onDelete}
             onTrackEnd={handleTrackEnd}
             selectionMode={selectionMode}
             selectedTracks={selectedTracks}
             toggleTrackSelection={toggleTrackSelection}
           />
 
-          {/* Pagination controls */}
           <TrackListPagination
-            currentPage={params.page!}
+            currentPage={params.page ?? 1}
             totalPages={totalPages}
-            onPageChange={handlePageChange}
+            onPageChange={onPageChange}
           />
         </>
       )}

--- a/src/components/TrackList/useTrackList.ts
+++ b/src/components/TrackList/useTrackList.ts
@@ -1,0 +1,99 @@
+import { useEffect, useState, useCallback } from "react";
+import { useAppDispatch } from "../../hooks/redux-hook";
+import { useTrackQueryParams } from "../../hooks/useTrackQueryParams";
+import { useDebounce } from "../../hooks/useDebounce";
+import { useTrackSelection } from "../../hooks/useTrackSelection";
+import { fetchGenres } from "../../features/genres/genresSlice";
+import { deleteTrack, fetchTracks } from "../../features/tracks/trackSlice";
+
+export function useTrackList(searchQuery: string) {
+  const dispatch = useAppDispatch();
+  const { query: params, setParam } = useTrackQueryParams();
+  const debouncedSearch = useDebounce(searchQuery, 500);
+
+  // bulk‐selection logic
+  const selection = useTrackSelection();
+  const onBulkDelete = useCallback(
+    () => selection.handleBulkDelete(selection.selectedTracks, params),
+    [selection, params],
+  );
+
+  // fetch genres once
+  useEffect(() => {
+    dispatch(fetchGenres()).unwrap().catch(console.error);
+  }, [dispatch]);
+
+  // sync external search → URL
+  useEffect(() => {
+    if (debouncedSearch !== params.search) {
+      setParam("search", debouncedSearch || undefined);
+      setParam("page", 1);
+    }
+  }, [debouncedSearch, params.search, setParam]);
+
+  // fetch tracks whenever URL params change
+  useEffect(() => {
+    dispatch(fetchTracks(params)).unwrap().catch(console.error);
+  }, [dispatch, params]);
+
+  // scroll to top on page change
+  useEffect(() => {
+    window.scrollTo({ top: 0 });
+  }, [params.page]);
+
+  // single‐track deletion
+  const onDelete = useCallback(
+    (id: string) => dispatch(deleteTrack(id)).unwrap().catch(console.error),
+    [dispatch],
+  );
+
+  // genre filter handler
+  const onGenreChange = useCallback(
+    (genre: string) => {
+      setParam("genre", genre || undefined);
+      setParam("page", 1);
+    },
+    [setParam],
+  );
+
+  // sort field handler
+  const onSortChange = useCallback(
+    (field: "" | "title" | "artist") => {
+      setParam("sort", field);
+      setParam(
+        "order",
+        params.sort === field && params.order === "asc" ? "desc" : "asc",
+      );
+      setParam("page", 1);
+    },
+    [params.sort, params.order, setParam],
+  );
+
+  // toggle sort direction
+  const onDirectionToggle = useCallback(() => {
+    setParam("order", params.order === "asc" ? "desc" : "asc");
+    setParam("page", 1);
+  }, [params.order, setParam]);
+
+  // pagination handler
+  const onPageChange = useCallback(
+    (newPage: number) => setParam("page", newPage),
+    [setParam],
+  );
+
+  return {
+    params,
+    debouncedSearch,
+    selectionMode: selection.selectionMode,
+    selectedTracks: selection.selectedTracks,
+    toggleSelectionMode: selection.toggleSelectionMode,
+    toggleTrackSelection: selection.toggleTrackSelection,
+    handleSelectAll: selection.handleSelectAll,
+    onBulkDelete,
+    onDelete,
+    onGenreChange,
+    onSortChange,
+    onDirectionToggle,
+    onPageChange,
+  };
+}

--- a/src/hooks/useTrackQueryParams.ts
+++ b/src/hooks/useTrackQueryParams.ts
@@ -1,0 +1,87 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { pipe, O } from "@mobily/ts-belt";
+import { useCallback, useMemo } from "react";
+import type { TracksQueryParams } from "../features/tracks/types";
+
+export function useTrackQueryParams() {
+  // read raw query string from current URL
+  const { search } = useLocation();
+  const navigate = useNavigate();
+
+  // memoize URLSearchParams so it changes only when `search` updates
+  const params = useMemo(() => new URLSearchParams(search), [search]);
+
+  // parse "page" param or default to 1
+  const page: number = pipe(
+    params.get("page"),
+    O.fromNullable,
+    O.map((s) => parseInt(s, 10)),
+    O.getWithDefault<number>(1),
+  );
+
+  // parse "limit" param or default to 10
+  const limit: number = pipe(
+    params.get("limit"),
+    O.fromNullable,
+    O.map((s) => parseInt(s, 10)),
+    O.getWithDefault<number>(10),
+  );
+
+  // parse "sort" param
+  const sort: TracksQueryParams["sort"] = pipe(
+    params.get("sort") as TracksQueryParams["sort"] | null,
+    O.fromNullable,
+    O.getWithDefault<TracksQueryParams["sort"]>(""),
+  );
+
+  // parse "order" param
+  const order: TracksQueryParams["order"] = pipe(
+    params.get("order") as TracksQueryParams["order"] | null,
+    O.fromNullable,
+    O.getWithDefault<TracksQueryParams["order"]>("asc"),
+  );
+
+  // parse "search" param
+  const searchText: string = pipe(
+    params.get("search"),
+    O.fromNullable,
+    O.getWithDefault<string>(""),
+  );
+
+  // parse "genre" param
+  const genre: string = pipe(
+    params.get("genre"),
+    O.fromNullable,
+    O.getWithDefault<string>(""),
+  );
+
+  // combine parsed values into a single query object, memoized on changes
+  const query = useMemo<TracksQueryParams>(
+    () => ({
+      page,
+      limit,
+      sort,
+      order,
+      search: searchText || undefined,
+      genre: genre || undefined,
+    }),
+    [page, limit, sort, order, searchText, genre],
+  );
+
+  // function to update a single query param and replace the URL
+  const setParam = useCallback(
+    <K extends keyof TracksQueryParams>(
+      key: K,
+      value: TracksQueryParams[K] | undefined,
+    ) => {
+      const p = new URLSearchParams(window.location.search);
+      if (value == null || value === "") p.delete(key as string);
+      else p.set(key as string, String(value));
+      void navigate({ search: p.toString() }, { replace: true });
+    },
+    [navigate],
+  );
+
+  // expose the current query and setter
+  return { query, setParam };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from "./App";
 import { Provider } from "react-redux";
 import { store } from "./store";
 import "react-toastify/dist/ReactToastify.css";
+import { BrowserRouter } from "react-router-dom";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
@@ -13,7 +14,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <Provider store={store}>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </Provider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
- Add @mobily/ts-belt to safely parse URL query parameters using Option.pipe + getWithDefault
- Implement useTrackQueryParams hook to memoize and map URLSearchParams → TracksQueryParams
- Extract TrackList business logic (fetching, search debounce, filters, sorting, pagination, selection) into new useTrackList hook
- Replace local state and effects in TrackList.tsx with URL-driven query + setParam API
- Coalesce undefined URL values at call sites (e.g. params.sort ?? "", params.page ?? 1) to satisfy non-nullable prop requirements
- Remove redundant useEffects and inline handlers from TrackList component, leaving only JSX
- Preserve scroll-to-top on page change within the hook