### PR TITLE
refactor: remove props from UI components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,55 +3,20 @@ import React, { useState } from "react";
 import TrackCreateModal from "./components/TrackCreateModal/TrackCreateModal";
 import TrackList from "./components/TrackList/TrackList";
 import TrackEditModal from "./components/TrackEditModal/TrackEditModal";
-import { Track } from "./features/tracks/types";
 import { ToastContainer } from "react-toastify";
 import Header from "./components/Header/Header";
-import { useAppDispatch } from "./hooks/redux-hook";
-import { deleteTrack } from "./features/tracks/trackSlice";
+
 
 function App() {
-  const [isModalOpen, setModalOpen] = useState(false);
-  const [editingTrack, setEditingTrack] = useState<Track | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [forceGoToFirstPage, setForceGoToFirstPage] = useState(false);
-  const dispatch = useAppDispatch();
-
-  const handleDelete = (id: string) => {
-    void dispatch(deleteTrack(id));
-  };
 
   return (
     <>
-      <Header
-        onCreate={() => setModalOpen(true)}
-        searchValue={searchQuery}
-        onSearchChange={(value) => {
-          setSearchQuery(value);
-          setForceGoToFirstPage(true);
-        }}
-      />
+      <Header />
       <main className="content">
-        <TrackList
-          onEditTrack={(track) => setEditingTrack(track)}
-          searchQuery={searchQuery}
-          forceGoToFirstPage={forceGoToFirstPage}
-          setForceGoToFirstPage={setForceGoToFirstPage}
-        />
+        <TrackList />
       </main>
-
-      {isModalOpen && (
-        <TrackCreateModal
-          onClose={() => setModalOpen(false)}
-          onCreated={() => setForceGoToFirstPage(true)}
-        />
-      )}
-      {editingTrack && (
-        <TrackEditModal
-          onDelete={handleDelete}
-          track={editingTrack}
-          onClose={() => setEditingTrack(null)}
-        />
-      )}
+        <TrackCreateModal />
+        <TrackEditModal />
       <ToastContainer position="top-right" autoClose={3000} />
     </>
   );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,48 +3,25 @@ import styles from "./Header.module.css";
 import Button from "../UI/Button/Button";
 import SearchInput from "../SearchInput/SearchInput";
 import Logo from "../../assets/logo.svg?react";
+import { useAppDispatch } from "../../hooks/redux-hook";
+import { openCreateModal } from "../../features/ui/modalSlice";
 
-interface Props {
-  onCreate: () => void;
-  searchValue: string;
-  onSearchChange: (value: string) => void;
-}
-
-const Header: React.FC<Props> = ({ onCreate, searchValue, onSearchChange }) => {
-  const [hidden, setHidden] = useState(false);
-  const [lastScrollY, setLastScrollY] = useState(0);
-
-  useEffect(() => {
-    const handleScroll = () => {
-      const currentY = window.scrollY;
-      setHidden(currentY > lastScrollY && currentY > 80);
-      setLastScrollY(currentY);
-    };
-
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, [lastScrollY]);
+const Header: React.FC = () => {
+  const dispatch = useAppDispatch();
 
   return (
-    <header
-      className={`${styles.header} ${hidden ? styles.hidden : ""}`}
-      data-testid="tracks-header"
-    >
+    <header className={styles.header} data-testid="tracks-header">
       <div className={styles.left}>
         <Logo className={styles.logo} />
       </div>
 
       <div className={styles.center}>
-        <SearchInput
-          data-testid="search-input"
-          value={searchValue}
-          onChange={onSearchChange}
-        />
+        <SearchInput />
       </div>
 
       <div className={styles.right}>
         <Button
-          onClick={onCreate}
+          onClick={() => dispatch(openCreateModal())}
           data-testid="create-track-button"
           variant="primary"
         >

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -1,26 +1,35 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import styles from "./SearchInput.module.css";
+import { useTrackQueryParams } from "../../hooks/useTrackQueryParams";
+import { useDebounce } from "../../hooks/useDebounce";
 
-interface Props {
-  value: string;
-  onChange: (value: string) => void;
-}
+const SearchInput: React.FC = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { query: params, setParams } = useTrackQueryParams();
 
-const SearchInput: React.FC<Props> = ({ value, onChange }) => {
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [local, setLocal] = useState(params.search ?? "");
+  const debouncedLocal = useDebounce(local, 500);
+  const isFirst = useRef(true);
 
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
+    if (isFirst.current) {
+      isFirst.current = false;
+      return;
+    }
+    setParams({ search: debouncedLocal || undefined, page: 1 });
+  }, [debouncedLocal, setParams]);
+
+  useEffect(() => {
+    const el = inputRef.current;
+    const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        onChange("");
-        inputRef.current?.blur();
+        setLocal("");
+        el?.blur();
       }
     };
-
-    const el = inputRef.current;
-    el?.addEventListener("keydown", handleKeyDown);
-    return () => el?.removeEventListener("keydown", handleKeyDown);
-  }, [onChange]);
+    el?.addEventListener("keydown", onKey);
+    return () => el?.removeEventListener("keydown", onKey);
+  }, []);
 
   return (
     <div className={styles.wrapper}>
@@ -28,17 +37,15 @@ const SearchInput: React.FC<Props> = ({ value, onChange }) => {
         ref={inputRef}
         type="text"
         placeholder="Search by title, artist, or album"
-        value={value}
-        onChange={(e) => {
-          onChange(e.target.value);
-        }}
+        value={local}
+        onChange={(e) => setLocal(e.target.value)}
         className={styles.input}
         data-testid="search-input"
       />
-      {value && (
+      {local && (
         <button
           type="button"
-          onClick={() => onChange("")}
+          onClick={() => setLocal("")}
           className={styles.clearButton}
           aria-label="Clear search"
         >

--- a/src/components/SortSelect/SortSelect.tsx
+++ b/src/components/SortSelect/SortSelect.tsx
@@ -1,25 +1,25 @@
 import React from "react";
 import styles from "./SortSelect.module.css";
+import { useTrackQueryParams } from "../../hooks/useTrackQueryParams";
 
-interface Props {
-  value: "" | "title" | "artist";
-  direction: "asc" | "desc";
-  onChange: (value: "title" | "artist" | "") => void;
-  onToggleDirection: () => void;
-}
+const SortSelect: React.FC = () => {
+  const { query: params, setParams } = useTrackQueryParams();
+  const value = params.sort || "";
+  const direction = params.order || "asc";
 
-const SortSelect: React.FC<Props> = ({
-  value,
-  direction,
-  onChange,
-  onToggleDirection,
-}) => {
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setParams({ sort: e.target.value as "" | "title" | "artist", page: 1 });
+  };
+  const handleToggleDirection = () => {
+    setParams({ order: direction === "asc" ? "desc" : "asc", page: 1 });
+  };
+
   return (
     <div className={styles.sortWrapper}>
       <div className={styles.customSelectWrapper}>
         <select
           value={value}
-          onChange={(e) => onChange(e.target.value as Props["value"])}
+          onChange={handleChange}
           className={styles.select}
           data-testid="sort-select"
         >
@@ -32,14 +32,10 @@ const SortSelect: React.FC<Props> = ({
           viewBox="0 0 12 8"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <polyline
-            points="1,1 6,6 11,1"
-            strokeWidth="2"
-            strokeLinecap="round"
-          />
+          <polyline points="1,1 6,6 11,1" strokeWidth="2" strokeLinecap="round" />
         </svg>
       </div>
-      <button onClick={onToggleDirection} className={styles.toggleButton}>
+      <button onClick={handleToggleDirection} className={styles.toggleButton}>
         {direction === "asc" ? "↑" : "↓"}
       </button>
     </div>

--- a/src/components/TrackCreateModal/TrackCreateModal.tsx
+++ b/src/components/TrackCreateModal/TrackCreateModal.tsx
@@ -1,71 +1,62 @@
 import React from "react";
+import { useAppDispatch } from "../../hooks/redux-hook";
+import { createTrack } from "../../features/tracks/trackSlice";
+import { selectAllTracks } from "../../features/tracks/trackSlice";
+import { selectCreateModalOpen, closeCreateModal } from "../../features/ui/modalSlice";
+import { useTrackQueryParams } from "../../hooks/useTrackQueryParams";
+import TrackForm from "../TrackForm/TrackForm";
+import ToastMessage from "../UI/ToastMessage/ToastMessage";
+import { toast } from "react-toastify";
+import { TrackFormSchema, TrackFormSchemaType } from "../../schemas/track";
+import ModalWrapper from "../UI/ModalWrapper/ModalWrapper";
 import { useSelector } from "react-redux";
 import { RootState } from "../../store";
-import TrackForm from "../TrackForm/TrackForm";
-import { createTrack } from "../../features/tracks/trackSlice";
-import { toast } from "react-toastify";
-import { useAppDispatch } from "../../hooks/redux-hook";
-import ToastMessage from "../UI/ToastMessage/ToastMessage";
-import ModalWrapper from "../UI/ModalWrapper/ModalWrapper";
-import { TrackFormSchema, TrackFormSchemaType } from "../../schemas/track";
 
-interface Props {
-  onClose: () => void;
-  onCreated: () => void;
-}
-
-const TrackCreateModal: React.FC<Props> = ({ onClose, onCreated }) => {
+const TrackCreateModal: React.FC = () => {
   const dispatch = useAppDispatch();
+  const open = useSelector(selectCreateModalOpen);
   const tracks = useSelector((state: RootState) => state.tracks.items);
+  const { setParams } = useTrackQueryParams();
+
+  if (!open) return null;
 
   const handleSubmit = async (data: TrackFormSchemaType) => {
     const titleLower = data.title.trim().toLowerCase();
-
     const isDuplicate = tracks.some(
-      (t) => t.title.trim().toLowerCase() === titleLower,
+      (t) => t.title.trim().toLowerCase() === titleLower
     );
-
     if (isDuplicate) {
       toast.error("A track with that name already exists!");
       return;
     }
-
     try {
       TrackFormSchema.parse(data);
-
-      const trackData = {
+      const payload = {
         title: data.title,
         artist: data.artist,
         album: data.album ?? "",
         genres: data.genres,
         coverImage: data.coverImage ?? "",
       };
-      await dispatch(createTrack(trackData));
-      onCreated();
-      onClose();
+      await dispatch(createTrack(payload)).unwrap();
+      // after create, reset page to 1
+      setParams({ page: 1 });
+      dispatch(closeCreateModal());
       toast.success(
-        <ToastMessage
-          message="Track successfully added!"
-          type="success"
-          data-testid="toast-success"
-        />,
+        <ToastMessage message="Track successfully added!" type="success" />
       );
-    } catch (error) {
-      console.error("Error creating track:", error);
+    } catch (err) {
+      console.error(err);
       toast.error(
-        <ToastMessage message="Failed to create track" type="error" />,
+        <ToastMessage message="Failed to create track" type="error" />
       );
     }
   };
 
   return (
-    <ModalWrapper onClose={onClose}>
+    <ModalWrapper onClose={() => dispatch(closeCreateModal())}>
       <h2 data-testid="tracks-header">Create a new track</h2>
-      <TrackForm
-        submitLabel="Create"
-        onSubmit={handleSubmit}
-        onCancel={onClose}
-      />
+      <TrackForm submitLabel="Create" onSubmit={handleSubmit} onCancel={() => dispatch(closeCreateModal())} />
     </ModalWrapper>
   );
 };

--- a/src/components/TrackEditModal/TrackEditModal.tsx
+++ b/src/components/TrackEditModal/TrackEditModal.tsx
@@ -1,30 +1,35 @@
 import React, { useState } from "react";
-import TrackForm from "../TrackForm/TrackForm";
-import styles from "./TrackEditModal.module.css";
-import { Track } from "../../features/tracks/types";
-import { editTrack } from "../../features/tracks/trackSlice";
 import { useAppDispatch } from "../../hooks/redux-hook";
-import { toast } from "react-toastify";
+import { selectEditTrackId, closeEditModal } from "../../features/ui/modalSlice";
+import { selectTrackById, editTrack, deleteTrack } from "../../features/tracks/trackSlice";
+import TrackForm from "../TrackForm/TrackForm";
+import ModalWrapper from "../UI/ModalWrapper/ModalWrapper";
 import ConfirmDialog from "../UI/ConfirmDialog/ConfirmDialog";
 import ToastMessage from "../UI/ToastMessage/ToastMessage";
-import ModalWrapper from "../UI/ModalWrapper/ModalWrapper";
-import { TrackFormSchemaType, TrackFormSchema } from "../../schemas/track";
+import { toast } from "react-toastify";
+import { TrackFormSchema, TrackFormSchemaType } from "../../schemas/track";
+import { useSelector } from "react-redux";
+import type { RootState } from "../../store";
+import styles from "./TrackEditModal.module.css";
 
-interface Props {
-  track: Track;
-  onClose: () => void;
-  onDelete: (id: string) => void;
-}
 
-const TrackEditModal: React.FC<Props> = ({ track, onClose, onDelete }) => {
+const TrackEditModal: React.FC = () => {
   const dispatch = useAppDispatch();
+  const editTrackId = useSelector(selectEditTrackId);
+  const track = useSelector((state: RootState) => {
+    if (editTrackId !== null && editTrackId !== "") {
+      return selectTrackById(state, editTrackId);
+    }
+    return null;
+  });
   const [showConfirm, setShowConfirm] = useState(false);
+
+  if (!track) return null;
 
   const handleSubmit = async (data: TrackFormSchemaType) => {
     try {
       TrackFormSchema.parse(data);
-
-      const trackData = {
+      const payload = {
         id: track.id,
         title: data.title,
         artist: data.artist,
@@ -32,63 +37,51 @@ const TrackEditModal: React.FC<Props> = ({ track, onClose, onDelete }) => {
         genres: data.genres,
         coverImage: data.coverImage ?? "",
       };
-      await dispatch(editTrack(trackData));
+      await dispatch(editTrack(payload)).unwrap();
       toast.success(
-        <ToastMessage message="Track successfully updated!" type="success" />,
+        <ToastMessage message="Track successfully updated!" type="success" />
       );
-      onClose();
-    } catch (error) {
-      console.error("Track editing error:", error);
+      dispatch(closeEditModal());
+    } catch (err) {
+      console.error(err);
       toast.error(
-        <ToastMessage message="Error while editing track" type="error" />,
+        <ToastMessage message="Error while editing track" type="error" />
       );
     }
   };
 
   const handleDelete = async () => {
-    try {
-      await onDelete(track.id);
-      toast.success(
-        <ToastMessage
-          message="Track deleted"
-          type="success"
-          data-testid="toast-delete-success"
-        />,
-      );
-      onClose();
-    } catch (err) {
-      console.error("Delete error:", err);
-      toast.error(<ToastMessage message="Error deleting track" type="error" />);
-    }
+    await dispatch(deleteTrack(track.id)).unwrap();
+    toast.success(
+      <ToastMessage message="Track deleted" type="success" />
+    );
+    dispatch(closeEditModal());
   };
 
   return (
-    <ModalWrapper onClose={onClose}>
+    <ModalWrapper onClose={() => dispatch(closeEditModal())}>
       <div className={styles.header}>
         <h2>Edit track</h2>
         <button
-          onClick={() => setShowConfirm(true)}
-          data-testid={`delete-track-${track.id}`}
-          className={styles.deleteButton}
-        >
-          Delete track
-        </button>
+        onClick={() => setShowConfirm(true)}
+        data-testid={`delete-track-${track.id}`}
+        className={styles.deleteButton}
+      >
+        Delete track
+      </button>
       </div>
 
       {showConfirm && (
         <ConfirmDialog
           message="Are you sure you want to delete this track?"
           onConfirm={async () => {
-            try {
-              await handleDelete();
-            } catch (err) {
-              console.error("Delete error in ConfirmDialog:", err);
-            }
+            await handleDelete();
             setShowConfirm(false);
           }}
           onCancel={() => setShowConfirm(false)}
         />
       )}
+
       <TrackForm
         initialValues={{
           title: track.title,
@@ -98,7 +91,7 @@ const TrackEditModal: React.FC<Props> = ({ track, onClose, onDelete }) => {
           coverImage: track.coverImage ?? "",
         }}
         onSubmit={handleSubmit}
-        onCancel={onClose}
+        onCancel={() => dispatch(closeEditModal())}
         submitLabel="Save"
       />
     </ModalWrapper>

--- a/src/components/TrackFilters/TrackFilters.tsx
+++ b/src/components/TrackFilters/TrackFilters.tsx
@@ -1,29 +1,25 @@
 import React from "react";
 import styles from "./TrackFilters.module.css";
+import { useTrackQueryParams } from "../../hooks/useTrackQueryParams";
+import { useSelector } from "react-redux";
+import type { RootState } from "../../store";
 
-interface Props {
-  genres: string[];
-  selectedGenre: string;
-  onGenreChange: (value: string) => void;
-  setCurrentPage: (page: number) => void;
-}
+const TrackFilters: React.FC = () => {
+  const { query: params, setParams } = useTrackQueryParams();
+  const genres = useSelector((state: RootState) => state.genres.items);
+  const selectedGenre = params.genre || "";
 
-const TrackFilters: React.FC<Props> = ({
-  genres,
-  selectedGenre,
-  onGenreChange,
-  setCurrentPage,
-}) => {
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setParams({ genre: e.target.value || undefined, page: 1 });
+  };
+
   return (
     <div className={styles.filtersWrapper}>
       <div className={styles.customSelectWrapper}>
         <select
           value={selectedGenre}
           aria-label="Genre"
-          onChange={(e) => {
-            onGenreChange(e.target.value);
-            setCurrentPage(1);
-          }}
+          onChange={handleChange}
           className={styles.select}
           data-testid="filter-genre"
         >
@@ -39,11 +35,7 @@ const TrackFilters: React.FC<Props> = ({
           viewBox="0 0 12 8"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <polyline
-            points="1,1 6,6 11,1"
-            strokeWidth="2"
-            strokeLinecap="round"
-          />
+          <polyline points="1,1 6,6 11,1" strokeWidth="2" strokeLinecap="round" />
         </svg>
       </div>
     </div>

--- a/src/components/TrackItem/TrackActions.tsx
+++ b/src/components/TrackItem/TrackActions.tsx
@@ -1,37 +1,50 @@
 import React from "react";
 import styles from "./TrackItem.module.css";
 import Dots from "../../assets/dots.svg?react";
+import { useAppDispatch } from "../../hooks/redux-hook";
+import { useSelector } from "react-redux";
+import {
+  selectSelectionMode,
+  selectSelectedIds,
+  toggleTrackSelection,
+} from "../../features/bulk-selection/selectionSlice";
+import { openEditModal } from "../../features/ui/modalSlice";
 
 interface Props {
-  onEdit: () => void;
-  showCheckbox?: boolean;
-  checked?: boolean;
-  onCheckboxChange?: () => void;
   trackId: string;
 }
 
-const TrackActions: React.FC<Props> = ({
-  onEdit,
-  showCheckbox,
-  checked,
-  onCheckboxChange,
-  trackId,
-}) => (
-  <div className={styles.mainActions}>
-    <button onClick={onEdit} data-testid={`edit-track-${trackId}`}>
-      <Dots className={styles.dots} />
-    </button>
-    {showCheckbox && (
-      <div className={styles.checkboxWrapper}>
-        <input
-          type="checkbox"
-          checked={checked}
-          onChange={onCheckboxChange}
-          className={styles.checkbox}
-        />
-      </div>
-    )}
-  </div>
-);
+const TrackActions: React.FC<Props> = ({ trackId }) => {
+  const dispatch = useAppDispatch();
+  const selectionMode = useSelector(selectSelectionMode);
+  const selectedIds = useSelector(selectSelectedIds);
+  const isChecked = selectedIds.includes(trackId);
+
+  const handleEdit = () => {
+    dispatch(openEditModal(trackId));
+  };
+
+  const handleCheckbox = () => {
+    dispatch(toggleTrackSelection(trackId));
+  };
+
+  return (
+    <div className={styles.mainActions}>
+      <button onClick={handleEdit} data-testid={`edit-track-${trackId}`}>
+        <Dots className={styles.dots} />
+      </button>
+      {selectionMode && (
+        <div className={styles.checkboxWrapper}>
+          <input
+            type="checkbox"
+            checked={isChecked}
+            onChange={handleCheckbox}
+            className={styles.checkbox}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
 
 export default TrackActions;

--- a/src/components/TrackItem/TrackInfo.tsx
+++ b/src/components/TrackItem/TrackInfo.tsx
@@ -1,25 +1,27 @@
 import React from "react";
 import styles from "./TrackItem.module.css";
+import { useSelector } from "react-redux";
+import { selectTrackById } from "../../features/tracks/trackSlice";
+import type { RootState } from "../../store";
 
-interface Props {
-  title: string;
-  artist: string;
-  album: string;
-  genres: string[];
-  id: string;
-}
+interface Props { id: string; }
 
-const TrackInfo: React.FC<Props> = ({ title, artist, album, genres, id }) => (
+
+const TrackInfo: React.FC<Props> = ({ id }) => {
+const track = useSelector((state: RootState) => selectTrackById(state, id));
+  if (!track) return null;
+
+  return(
   <div className={styles.info}>
     <div className={styles.title} data-testid={`track-item-${id}-title`}>
-      {title}
+      {track.title}
     </div>
     <div className={styles.artist} data-testid={`track-item-${id}-artist`}>
-      {artist}
+      {track.artist}
     </div>
-    <div className={styles.album}>{album}</div>
+    <div className={styles.album}>{track.album}</div>
     <div className={styles.genres}>
-      {genres.map((g) => (
+      {track.genres.map((g) => (
         <span key={g} className={styles.genre}>
           {g}
         </span>
@@ -27,5 +29,6 @@ const TrackInfo: React.FC<Props> = ({ title, artist, album, genres, id }) => (
     </div>
   </div>
 );
+};
 
 export default TrackInfo;

--- a/src/components/TrackItem/TrackItem.tsx
+++ b/src/components/TrackItem/TrackItem.tsx
@@ -8,52 +8,19 @@ import TrackActions from "./TrackActions";
 
 interface Props {
   track: Track;
-  isActive: boolean;
-  onEdit: (track: Track) => void;
-  onTogglePlay: () => void;
-  onTrackEnd: () => void;
-  selectionMode?: boolean;
-  selected?: boolean;
-  onToggleSelect?: () => void;
 }
 
 const TrackItem: React.FC<Props> = ({
   track,
-  isActive,
-  onEdit,
-  onTogglePlay,
-  onTrackEnd,
-  selectionMode,
-  selected,
-  onToggleSelect,
 }) => {
   return (
     <li className={styles.trackItem} data-testid={`track-item-${track.id}`}>
       <div className={styles.trackInfo}>
         <TrackCover src={track.coverImage} alt={track.title} />
-        <TrackInfo
-          title={track.title}
-          artist={track.artist}
-          album={track.album}
-          genres={track.genres}
-          id={track.id}
-        />
+        <TrackInfo id={track.id}/>
       </div>
-      <TrackPlayer
-        trackId={track.id}
-        audioFile={track.audioFile}
-        isActive={isActive}
-        onTogglePlay={onTogglePlay}
-        onTrackEnd={onTrackEnd}
-        updatedAt={track.updatedAt}
-      />
-      <TrackActions
-        onEdit={() => onEdit(track)}
-        showCheckbox={selectionMode}
-        checked={selected}
-        onCheckboxChange={onToggleSelect}
-        trackId={track.id}
-      />
+      <TrackPlayer trackId={track.id} />
+      <TrackActions trackId={track.id} />
     </li>
   );
 };

--- a/src/components/TrackItem/TrackPlayer.tsx
+++ b/src/components/TrackItem/TrackPlayer.tsx
@@ -1,41 +1,50 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import styles from "./TrackItem.module.css";
 import CustomAudioPlayer from "../CustomAudioPlayer/CustomAudioPlayer";
 import TrackUpload from "../TrackUpload/TrackUpload";
 import { API_BASE } from "../../api/config";
-
+import type { RootState } from "../../store";
+import { selectTrackById } from "../../features/tracks/trackSlice";
+import { togglePlay, playNext, selectActiveTrackId, selectIsPlaying } from "../../features/player/playerSlice";
+import { useAppDispatch } from "../../hooks/redux-hook";
 interface Props {
   trackId: string;
-  audioFile?: string;
-  updatedAt: string;
-  isActive: boolean;
-  onTogglePlay: () => void;
-  onTrackEnd: () => void;
 }
 
-const TrackPlayer: React.FC<Props> = ({
-  trackId,
-  audioFile,
-  isActive,
-  onTogglePlay,
-  onTrackEnd,
-  updatedAt,
-}) => (
-  <div className={styles.player}>
-    {audioFile && (
+const TrackPlayer: React.FC<Props> = ({ trackId }) => {
+  const dispatch = useAppDispatch();
+  
+  // Select track data
+  const track = useSelector((state: RootState) => selectTrackById(state, trackId));
+  const audioFile = track?.audioFile;
+  const updatedAt = track?.updatedAt || "";
+
+  // Select player state
+  const activeTrackId = useSelector((state: RootState) => selectActiveTrackId(state));
+  const isPlaying = useSelector((state: RootState) => selectIsPlaying(state));
+  const isActive = activeTrackId === trackId && isPlaying;
+
+  // Handlers
+  const handleTogglePlay = () => dispatch(togglePlay({ id: trackId }));
+  const handleTrackEnd    = () => dispatch(playNext());
+
+
+  return (
+    <div className={styles.player}>
       <div className={styles.audioWrapper}>
-        <CustomAudioPlayer
+        {audioFile && <CustomAudioPlayer
           src={`${API_BASE}/files/${audioFile}?v=${updatedAt}`}
           isActive={isActive}
-          onTogglePlay={onTogglePlay}
-          onEndedNext={onTrackEnd}
-        />
+          onTogglePlay={handleTogglePlay}
+          onEndedNext={handleTrackEnd}
+        />}
       </div>
-    )}
-    <div className={styles.actions}>
-      <TrackUpload trackId={trackId} />
+      <div className={styles.actions}>
+        <TrackUpload trackId={trackId} />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default TrackPlayer;

--- a/src/components/TrackList/TrackList.tsx
+++ b/src/components/TrackList/TrackList.tsx
@@ -1,56 +1,17 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import styles from "./TrackList.module.css";
 import Preloader from "../Preloader/Preloader";
 import TrackListControls from "./TrackListControls";
 import TrackListContent from "./TrackListContent";
 import TrackListPagination from "./TrackListPagination";
-import { Track } from "../../features/tracks/types";
 import { useTracks } from "../../hooks/useTracks";
-import { useSelector } from "react-redux";
-import { RootState } from "../../store";
 import TrackBulkActions from "../TrackBulkActions/TrackBulkActions";
 import { useTrackList } from "./useTrackList";
 
-interface Props {
-  onEditTrack: (track: Track) => void;
-  searchQuery: string;
-  forceGoToFirstPage: boolean;
-  setForceGoToFirstPage: React.Dispatch<React.SetStateAction<boolean>>;
-}
+const TrackList: React.FC = () => {
+  useTrackList();
 
-const TrackList: React.FC<Props> = ({ onEditTrack, searchQuery }) => {
-  // Select paginated track data and metadata from Redux state
-  const { items, status, limit, totalPages, error } = useTracks();
-
-  const {
-    params,
-    onDelete,
-    onGenreChange,
-    onSortChange,
-    onDirectionToggle,
-    onPageChange,
-    selectionMode,
-    selectedTracks,
-    toggleSelectionMode,
-    toggleTrackSelection,
-    handleSelectAll,
-    onBulkDelete,
-  } = useTrackList(searchQuery);
-  // Select available genres from Redux state
-  const { items: genres } = useSelector((s: RootState) => s.genres);
-
-  // State for tracking which track is playing globally (index within items)
-  const [currentPlayingIndex, setCurrentPlayingIndex] = useState<number | null>(
-    null,
-  );
-
-  const handleTrackEnd = (localIndex: number) => {
-    if (localIndex + 1 < items.length) {
-      setCurrentPlayingIndex(localIndex + 1);
-    } else {
-      setCurrentPlayingIndex(null);
-    }
-  };
+  const { items, status, error } = useTracks();
 
   return (
     <div className={styles.trackList}>
@@ -59,45 +20,10 @@ const TrackList: React.FC<Props> = ({ onEditTrack, searchQuery }) => {
 
       {items.length > 0 && (
         <>
-          {/* Controls for sorting, filtering, and searching */}
-          <TrackListControls
-            sortBy={params.sort ?? ""}
-            sortDirection={params.order ?? "asc"}
-            onSortChange={onSortChange}
-            onToggleDirection={onDirectionToggle}
-            selectedGenre={params.genre ?? ""}
-            onGenreChange={onGenreChange}
-            genres={genres}
-            setCurrentPage={onPageChange}
-          />
-
-          <TrackBulkActions
-            selectionMode={selectionMode}
-            selectedCount={selectedTracks.length}
-            totalCount={items.length}
-            onToggleMode={toggleSelectionMode}
-            onSelectAll={() => handleSelectAll(items.map((t) => t.id))}
-            onBulkDelete={onBulkDelete}
-          />
-
-          <TrackListContent
-            tracks={items}
-            startIndex={((params.page ?? 1) - 1) * limit}
-            currentPlayingIndex={currentPlayingIndex}
-            setCurrentPlayingIndex={setCurrentPlayingIndex}
-            onEditTrack={onEditTrack}
-            onDeleteTrack={onDelete}
-            onTrackEnd={handleTrackEnd}
-            selectionMode={selectionMode}
-            selectedTracks={selectedTracks}
-            toggleTrackSelection={toggleTrackSelection}
-          />
-
-          <TrackListPagination
-            currentPage={params.page ?? 1}
-            totalPages={totalPages}
-            onPageChange={onPageChange}
-          />
+          <TrackListControls />
+          <TrackBulkActions />
+          <TrackListContent tracks={items} />
+          <TrackListPagination />
         </>
       )}
     </div>

--- a/src/components/TrackList/TrackListContent.tsx
+++ b/src/components/TrackList/TrackListContent.tsx
@@ -5,53 +5,20 @@ import { Track } from "../../features/tracks/types";
 
 interface Props {
   tracks: Track[];
-  startIndex: number;
-  currentPlayingIndex: number | null;
-  setCurrentPlayingIndex: (index: number | null) => void;
-  onEditTrack: (track: Track) => void;
-  onDeleteTrack: (id: string) => void;
-  onTrackEnd: (index: number) => void;
-  selectionMode: boolean;
-  selectedTracks: string[];
-  toggleTrackSelection: (id: string) => void;
 }
 
 const TrackListContent: React.FC<Props> = ({
   tracks,
-  startIndex,
-  currentPlayingIndex,
-  setCurrentPlayingIndex,
-  onEditTrack,
-  onDeleteTrack,
-  onTrackEnd,
-  selectionMode,
-  selectedTracks,
-  toggleTrackSelection,
 }) => {
   if (tracks.length === 0) {
-    return <p className={styles.noResults}>Нічого не знайдено</p>;
+    return <p className={styles.noResults}>Nothing found</p>;
   }
 
   return (
     <ul className={`${styles.list} ${styles.fadeIn}`}>
-      {tracks.map((track, index) => {
-        const globalIndex = startIndex + index;
+      {tracks.map((track) => {
         return (
-          <TrackItem
-            key={track.id}
-            track={track}
-            isActive={currentPlayingIndex === globalIndex}
-            onEdit={() => onEditTrack(track)}
-            onTogglePlay={() =>
-              setCurrentPlayingIndex(
-                currentPlayingIndex === globalIndex ? null : globalIndex,
-              )
-            }
-            onTrackEnd={() => onTrackEnd(globalIndex)}
-            selectionMode={selectionMode}
-            selected={selectedTracks.includes(track.id)}
-            onToggleSelect={() => toggleTrackSelection(track.id)}
-          />
+          <TrackItem track={track} key={track.id} />
         );
       })}
     </ul>

--- a/src/components/TrackList/TrackListControls.tsx
+++ b/src/components/TrackList/TrackListControls.tsx
@@ -1,43 +1,13 @@
 import React from "react";
+import styles from "./TrackList.module.css";
 import SortSelect from "../SortSelect/SortSelect";
 import TrackFilters from "../TrackFilters/TrackFilters";
-import styles from "./TrackList.module.css";
 
-interface Props {
-  sortBy: "" | "title" | "artist";
-  sortDirection: "asc" | "desc";
-  onSortChange: (field: "" | "title" | "artist") => void;
-  onToggleDirection: () => void;
-  selectedGenre: string;
-  onGenreChange: (genre: string) => void;
-  genres: string[];
-  setCurrentPage: (page: number) => void;
-}
-
-const TrackListControls: React.FC<Props> = ({
-  sortBy,
-  sortDirection,
-  onSortChange,
-  onToggleDirection,
-  selectedGenre,
-  onGenreChange,
-  genres,
-  setCurrentPage,
-}) => {
+const TrackListControls: React.FC = () => {
   return (
     <div className={styles.controls}>
-      <SortSelect
-        value={sortBy}
-        onChange={onSortChange}
-        direction={sortDirection}
-        onToggleDirection={onToggleDirection}
-      />
-      <TrackFilters
-        genres={genres}
-        selectedGenre={selectedGenre}
-        onGenreChange={onGenreChange}
-        setCurrentPage={setCurrentPage}
-      />
+      <SortSelect />
+      <TrackFilters />
     </div>
   );
 };

--- a/src/components/TrackList/TrackListPagination.tsx
+++ b/src/components/TrackList/TrackListPagination.tsx
@@ -1,24 +1,25 @@
 import React from "react";
 import Pagination from "../Pagination/Pagination";
 import styles from "./TrackList.module.css";
+import { useTrackQueryParams } from "../../hooks/useTrackQueryParams";
+import { useSelector } from "react-redux";
+import type { RootState } from "../../store";
 
-interface Props {
-  currentPage: number;
-  totalPages: number;
-  onPageChange: (page: number) => void;
-}
+const TrackListPagination: React.FC = () => {
+  const { query: params, setParams } = useTrackQueryParams();
+  const currentPage = params.page ?? 1;
+  const totalPages = useSelector((state: RootState) => state.tracks.totalPages);
 
-const TrackListPagination: React.FC<Props> = ({
-  currentPage,
-  totalPages,
-  onPageChange,
-}) => {
+  const handlePageChange = (page: number) => {
+    setParams({ page });
+  };
+
   return (
     <div className={styles.paginationWrapper}>
       <Pagination
         currentPage={currentPage}
         totalPages={totalPages}
-        onPageChange={onPageChange}
+        onPageChange={handlePageChange}
       />
     </div>
   );

--- a/src/features/bulk-selection/selectionSlice.ts
+++ b/src/features/bulk-selection/selectionSlice.ts
@@ -1,0 +1,54 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import type { RootState } from "../../store";
+
+//Slice to manage selection mode and selected track IDs for bulk actions
+interface SelectionState {
+  selectionMode: boolean;
+  selectedIds: string[];
+}
+
+const initialState: SelectionState = {
+  selectionMode: false,
+  selectedIds: [],
+};
+
+const selectionSlice = createSlice({
+  name: "selection",
+  initialState,
+  reducers: {
+    toggleSelectionMode(state) {
+      state.selectionMode = !state.selectionMode;
+      if (!state.selectionMode) {
+        state.selectedIds = [];
+      }
+    },
+    toggleTrackSelection(state, action: PayloadAction<string>) {
+      const id = action.payload;
+      if (state.selectedIds.includes(id)) {
+        state.selectedIds = state.selectedIds.filter((tid) => tid !== id);
+      } else {
+        state.selectedIds.push(id);
+      }
+    },
+    selectAll(state, action: PayloadAction<string[]>) {
+      state.selectedIds = action.payload;
+    },
+    clearSelection(state) {
+      state.selectedIds = [];
+    },
+  },
+});
+
+export const {
+  toggleSelectionMode,
+  toggleTrackSelection,
+  selectAll,
+  clearSelection,
+} = selectionSlice.actions;
+
+// Selector to read selection mode flag 
+export const selectSelectionMode = (state: RootState) => state.selection.selectionMode;
+// Selector to read selected track IDs
+export const selectSelectedIds    = (state: RootState) => state.selection.selectedIds;
+
+export default selectionSlice.reducer;

--- a/src/features/player/playerSlice.ts
+++ b/src/features/player/playerSlice.ts
@@ -1,0 +1,62 @@
+import { createSlice, PayloadAction, createAsyncThunk } from "@reduxjs/toolkit";
+import type { RootState } from "../../store";
+import { selectAllTracks } from "../tracks/trackSlice";
+
+interface PlayerState {
+  activeTrackId: string | null;
+  isPlaying: boolean;
+}
+
+const initialState: PlayerState = {
+  activeTrackId: null,
+  isPlaying: false,
+};
+
+const playerSlice = createSlice({
+  name: "player",
+  initialState,
+  reducers: {
+    togglePlay(state, action: PayloadAction<{ id: string }>) {
+      const { id } = action.payload;
+      if (state.activeTrackId === id) {
+        state.isPlaying = !state.isPlaying;
+      } else {
+        state.activeTrackId = id;
+        state.isPlaying = true;
+      }
+    },
+    trackEnded(state, action: PayloadAction<{ id: string }>) {
+      if (state.activeTrackId === action.payload.id) {
+        state.isPlaying = false;
+      }
+    },
+  },
+});
+
+export const { togglePlay, trackEnded } = playerSlice.actions;
+
+export const selectActiveTrackId = (state: RootState) => state.player.activeTrackId;
+export const selectIsPlaying     = (state: RootState) => state.player.isPlaying;
+
+//Async thunk to play next track based on current playlist order
+export const playNext = createAsyncThunk<
+  void,
+  void,
+  { state: RootState }
+>(
+  "player/playNext",
+  async (_, { getState, dispatch }) => {
+    const state = getState();
+    const tracks = selectAllTracks(state);
+    const ids = tracks.map((t) => t.id);
+    const currentId = state.player.activeTrackId;
+    const idx = ids.findIndex((id) => id === currentId);
+    if (idx >= 0 && idx + 1 < ids.length) {
+      dispatch(togglePlay({ id: ids[idx + 1] }));
+    } else if (currentId) {
+      dispatch(trackEnded({ id: currentId }));
+    }
+  },
+);
+
+export default playerSlice.reducer;

--- a/src/features/ui/modalSlice.ts
+++ b/src/features/ui/modalSlice.ts
@@ -1,0 +1,50 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import type { RootState } from "../../store";
+
+//UI state for modals: edit track ID and create-track modal open flag.
+interface ModalState {
+  editTrackId: string | null;
+  createModalOpen: boolean;
+}
+
+const initialState: ModalState = {
+  editTrackId: null,
+  createModalOpen: false,
+};
+
+const modalSlice = createSlice({
+  name: "modal",
+  initialState,
+  reducers: {
+    //Open the edit modal for a given track ID.
+    openEditModal(state, action: PayloadAction<string>) {
+      state.editTrackId = action.payload;
+    },
+    //Close the edit modal.
+    closeEditModal(state) {
+      state.editTrackId = null;
+    },
+    //Open the create-track modal.
+    openCreateModal(state) {
+      state.createModalOpen = true;
+    },
+    //Close the create-track modal.
+    closeCreateModal(state) {
+      state.createModalOpen = false;
+    },
+  },
+});
+
+export const {
+  openEditModal,
+  closeEditModal,
+  openCreateModal,
+  closeCreateModal,
+} = modalSlice.actions;
+
+// Selector to get the currently editing track ID (or null if closed).
+export const selectEditTrackId = (state: RootState) => state.modal.editTrackId;
+//Selector to get create-track modal open flag.
+export const selectCreateModalOpen = (state: RootState) => state.modal.createModalOpen;
+
+export default modalSlice.reducer;

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,11 +1,17 @@
 import { configureStore } from "@reduxjs/toolkit";
 import tracksReducer from "./features/tracks/trackSlice";
 import genresReducer from "./features/genres/genresSlice";
+import playerReducer from "./features/player/playerSlice";
+import selectionReducer from './features/bulk-selection/selectionSlice'
+import modalReducer from './features/ui/modalSlice'
 
 export const store = configureStore({
   reducer: {
     tracks: tracksReducer,
     genres: genresReducer,
+    player: playerReducer,
+    selection: selectionReducer,
+    modal: modalReducer,
   },
 });
 


### PR DESCRIPTION
- Eliminate prop drilling by having components read state and dispatch actions directly via Redux slices and hooks
- Header now opens create modal via modalSlice and syncs search input with URL params internally
- SearchInput manages its own local state and debounced URL updates instead of receiving value/onChange props
- TrackList and its children (TrackListControls, TrackBulkActions, TrackListContent, TrackListPagination) consume params and data via custom hooks and selectors
- TrackCreateModal & TrackEditModal open/close via modalSlice and dispatch create/edit/delete track thunks without external props